### PR TITLE
Restore capacity to 2 now we have scalable reference number generator

### DIFF
--- a/app-service-plan.tf
+++ b/app-service-plan.tf
@@ -2,7 +2,7 @@ locals {
   ase_name = "core-compute-${var.env}"
   asp_name_without_env = "${var.product}"
 
-  asp_capacity = "1"
+  asp_capacity = "${var.env == "prod" || var.env == "sprod" ? "2"  : "1"}"
   asp_sku_size = "${var.env == "prod" || var.env == "sprod" ? "I2" : "I1"}"
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Restore the capacity to `2` now we now have a DB based reference number generator that can work with multiple API clients.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
